### PR TITLE
Implement Energy ruleset and relay menu

### DIFF
--- a/src/main/java/com/m_w_k/synapse/SynapseMod.java
+++ b/src/main/java/com/m_w_k/synapse/SynapseMod.java
@@ -2,6 +2,7 @@ package com.m_w_k.synapse;
 
 import com.m_w_k.synapse.client.gui.BasicConnectorScreen;
 import com.m_w_k.synapse.client.gui.EndpointScreen;
+import com.m_w_k.synapse.client.gui.RelayScreen;
 import com.m_w_k.synapse.client.renderer.TestAxonRenderer;
 import com.m_w_k.synapse.common.menu.EndpointMenu;
 import com.m_w_k.synapse.data.SynapseLootTableGen;
@@ -63,6 +64,7 @@ public final class SynapseMod {
                 () -> {
                     MenuScreens.register(SynapseMenuRegistry.BASIC_CONNECTOR.get(), BasicConnectorScreen::new);
                     MenuScreens.register(SynapseMenuRegistry.ENDPOINT.get(), EndpointScreen::new);
+                    MenuScreens.register(SynapseMenuRegistry.RELAY.get(), RelayScreen::new);
                 }
         );
     }

--- a/src/main/java/com/m_w_k/synapse/api/block/AxonDeviceDefinitions.java
+++ b/src/main/java/com/m_w_k/synapse/api/block/AxonDeviceDefinitions.java
@@ -1,5 +1,6 @@
 package com.m_w_k.synapse.api.block;
 
+import com.m_w_k.synapse.api.block.ruleset.EnergyTransferRuleset;
 import com.m_w_k.synapse.api.block.ruleset.FluidTransferRuleset;
 import com.m_w_k.synapse.api.block.ruleset.ItemTransferRuleset;
 import com.m_w_k.synapse.api.block.ruleset.TransferRuleset;
@@ -57,6 +58,7 @@ public final class AxonDeviceDefinitions {
         }
         ENDPOINT_RULES.put(AxonType.ITEM, new ItemTransferRuleset(Dist.DEDICATED_SERVER));
         ENDPOINT_RULES.put(AxonType.FLUID, new FluidTransferRuleset(Dist.DEDICATED_SERVER));
+        ENDPOINT_RULES.put(AxonType.ENERGY, new EnergyTransferRuleset(Dist.DEDICATED_SERVER));
         ENDPOINT_CAPABILITIES.put(AxonType.ITEM, ItemExposer::new);
         ENDPOINT_CAPABILITIES.put(AxonType.FLUID, FluidExposer::new);
         ENDPOINT_CAPABILITIES.put(AxonType.ENERGY, EnergyExposer::new);

--- a/src/main/java/com/m_w_k/synapse/api/block/ruleset/BasicRule.java
+++ b/src/main/java/com/m_w_k/synapse/api/block/ruleset/BasicRule.java
@@ -1,0 +1,64 @@
+package com.m_w_k.synapse.api.block.ruleset;
+
+import com.m_w_k.synapse.api.connect.AxonAddress;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+
+public class BasicRule implements RuleAccess {
+
+    public static final Codec<BasicRule> CODEC = RecordCodecBuilder.create(instance ->
+            instance.group(
+                    AxonAddress.CODEC.fieldOf("address").forGetter(BasicRule::getAddress),
+                    Codec.BOOL.fieldOf("matchesIncoming").forGetter(BasicRule::isMatchesIncoming),
+                    Codec.BOOL.fieldOf("matchesOutgoing").forGetter(BasicRule::isMatchesOutgoing)
+            ).apply(instance, BasicRule::new));
+
+    @NotNull
+    protected AxonAddress address;
+    protected boolean matchesIncoming;
+    protected boolean matchesOutgoing;
+
+    public BasicRule() {
+        this.address = new AxonAddress();
+    }
+
+    public BasicRule(@NotNull AxonAddress address, boolean matchesIncoming, boolean matchesOutgoing) {
+        this.address = address;
+        this.matchesIncoming = matchesIncoming;
+        this.matchesOutgoing = matchesOutgoing;
+    }
+
+    @Override
+    public @NotNull AxonAddress getAddress() {
+        return address;
+    }
+
+    @Override
+    public void setAddress(@NotNull AxonAddress address) {
+        this.address = address;
+    }
+
+    @Override
+    public boolean isMatchesIncoming() {
+        return matchesIncoming;
+    }
+
+    @Override
+    public void setMatchesIncoming(boolean matchesIncoming) {
+        this.matchesIncoming = matchesIncoming;
+    }
+
+    @Override
+    public boolean isMatchesOutgoing() {
+        return matchesOutgoing;
+    }
+
+    @Override
+    public void setMatchesOutgoing(boolean matchesOutgoing) {
+        this.matchesOutgoing = matchesOutgoing;
+    }
+}

--- a/src/main/java/com/m_w_k/synapse/api/block/ruleset/EnergyTransferRuleset.java
+++ b/src/main/java/com/m_w_k/synapse/api/block/ruleset/EnergyTransferRuleset.java
@@ -1,0 +1,284 @@
+package com.m_w_k.synapse.api.block.ruleset;
+
+import com.m_w_k.synapse.api.connect.AxonAddress;
+import com.m_w_k.synapse.api.connect.AxonType;
+import com.m_w_k.synapse.api.connect.ConnectorLevel;
+import com.m_w_k.synapse.client.gui.AbstractConnectorScreen;
+import com.m_w_k.synapse.client.gui.ruleset.EnergyRulesetWidget;
+import com.m_w_k.synapse.client.gui.ruleset.ItemRulesetWidget;
+import com.m_w_k.synapse.client.gui.ruleset.RulesetWidget;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class EnergyTransferRuleset implements TransferRuleset.QueryableRuleset<Void> {
+
+    public static final Codec<EnergyTransferRuleset> CODEC = RecordCodecBuilder.create(instance ->
+            instance.group(
+                    Codec.list(BasicRule.CODEC).fieldOf("rules").forGetter(r -> r.rules)
+                    ).apply(instance, EnergyTransferRuleset::new));
+
+    protected final @NotNull List<BasicRule> rules;
+    private final Dist dist;
+
+    protected List<Consumer<FriendlyByteBuf>> toSync = new ObjectArrayList<>();
+
+    protected Runnable changeListener = () -> {};
+
+    public EnergyTransferRuleset(Dist dist) {
+        this.dist = dist;
+        this.rules = new ObjectArrayList<>();
+        this.rules.add(defaultRule());
+    }
+
+    protected EnergyTransferRuleset(List<BasicRule> rules) {
+        this.rules = new ObjectArrayList<>(rules);
+        this.dist = Dist.DEDICATED_SERVER;
+    }
+
+    protected BasicRule defaultRule() {
+        AxonAddress address = new AxonAddress();
+        ConnectorLevel.ADDRESS_SPACE.forEach(l -> address.put(l, AxonAddress.WILDCARD));
+        address.put(ConnectorLevel.ENDPOINT, AxonAddress.WILDCARD);
+        return new BasicRule(address, true, false);
+    }
+
+    public void setChangeListener(@NotNull Runnable changeListener) {
+        this.changeListener = changeListener;
+    }
+
+    public @NotNull RuleAccess ruleAt(int index) {
+        if (dist.isClient()) {
+            return new ProtectedRuleAccess(rules.get(index), index);
+        }
+        return rules.get(index);
+    }
+
+    protected @NotNull BasicRule actualRuleAt(int index) {
+        return rules.get(index);
+    }
+
+    public int ruleCount() {
+        return rules.size();
+    }
+
+    public void applyAction(int index, RuleAction action) {
+        switch (action) {
+            case SHIFT_LEFT -> {
+                BasicRule replace = rules.set(index - 1, rules.get(index));
+                rules.set(index, replace);
+            }
+            case SHIFT_RIGHT -> {
+                BasicRule replace = rules.set(index + 1, rules.get(index));
+                rules.set(index, replace);
+            }
+            case DELETE -> {
+                rules.remove(index);
+                if (rules.isEmpty()) {
+                    rules.add(defaultRule());
+                }
+            }
+            case ADD -> {
+                rules.add(index, new BasicRule());
+            }
+        }
+        toSync.add(buf -> {
+            buf.writeEnum(action);
+            buf.writeVarInt(index);
+        });
+    }
+
+    @Override
+    @UnmodifiableView
+    public @Nullable AxonAddress getMatchingAddress(@NotNull Void unused, boolean incoming) {
+        for (BasicRule rule : rules) {
+            if (incoming && !rule.isMatchesIncoming()) continue;
+            if (!incoming && !rule.isMatchesOutgoing()) continue;
+            return rule.getAddress();
+        }
+        return null;
+    }
+
+    @Override
+    public @NotNull Collection<AxonAddress> getAllPossibleAddresses() {
+        return rules.stream().map(BasicRule::getAddress).toList();
+    }
+
+    @Override
+    public @NotNull TransferRuleset createNew(Dist dist) {
+        return new EnergyTransferRuleset(dist);
+    }
+
+    @Override
+    public @NotNull Consumer<TransferRuleset> syncAction(FriendlyByteBuf buf, Dist destination) {
+        if (destination.isClient()) {
+            int count = buf.readVarInt();
+            List<BasicRule> overwrite = new ObjectArrayList<>();
+            for (int i = 0; i < count; i++) {
+                BasicRule rule = new BasicRule();
+                rule.address.read(buf);
+                rule.matchesIncoming = buf.readBoolean();
+                rule.matchesOutgoing = buf.readBoolean();
+                overwrite.add(rule);
+            }
+            return r -> {
+                if (r instanceof EnergyTransferRuleset item) {
+                    item.rules.clear();
+                    item.rules.addAll(overwrite);
+                    item.changeListener.run();
+                }
+            };
+        } else {
+            int count = buf.readVarInt();
+            final List<Consumer<EnergyTransferRuleset>> actions = new ObjectArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                RuleAction action = buf.readEnum(RuleAction.class);
+                int index = buf.readVarInt();
+                if (action == RuleAction.MODIFY) {
+                    var act = buf.readEnum(ProtectedRuleAccess.ModifyType.class);
+                    switch (act) {
+                        case ADDRESS -> {
+                            AxonAddress address = new AxonAddress();
+                            address.read(buf);
+                            actions.add(r -> r.actualRuleAt(index).setAddress(address));
+                        }
+                        case INCOMING -> {
+                            boolean incoming = buf.readBoolean();
+                            actions.add(r -> r.actualRuleAt(index).setMatchesIncoming(incoming));
+                        }
+                        case OUTGOING -> {
+                            boolean outgoing = buf.readBoolean();
+                            actions.add(r -> r.actualRuleAt(index).setMatchesOutgoing(outgoing));
+                        }
+                    }
+                } else {
+                    actions.add(r -> r.applyAction(index, action));
+                }
+            }
+            return r -> {
+                if (r instanceof EnergyTransferRuleset item) {
+                    for (Consumer<EnergyTransferRuleset> a : actions) {
+                        a.accept(item);
+                    }
+                    item.changeListener.run();
+                }
+            };
+        }
+    }
+
+    @Override
+    public @NotNull Consumer<FriendlyByteBuf> clientSyncData() {
+        return buf -> {
+            buf.writeVarInt(rules.size());
+            for (int i = 0; i < rules.size(); i++) {
+                BasicRule rule = rules.get(i);
+                rule.address.write(buf);
+                buf.writeBoolean(rule.matchesIncoming);
+                buf.writeBoolean(rule.matchesOutgoing);
+            }
+        };
+    }
+
+    @Override
+    public @NotNull AxonType getType() {
+        return AxonType.ENERGY;
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    @Override
+    public @NotNull Consumer<FriendlyByteBuf> serverSyncData(@NotNull RulesetWidget widget) {
+        var list = toSync;
+        toSync = new ObjectArrayList<>();
+        return buf -> {
+            buf.writeVarInt(list.size());
+            for (Consumer<FriendlyByteBuf> action : list) {
+                action.accept(buf);
+            }
+        };
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    @Override
+    public boolean hasPendingSync(@NotNull RulesetWidget widget) {
+        return !toSync.isEmpty();
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    @Override
+    public @NotNull RulesetWidget createWidget(AbstractConnectorScreen<?> parent, int x, int y) {
+        return new EnergyRulesetWidget(this, parent, x, y);
+    }
+
+    public class ProtectedRuleAccess implements RuleAccess {
+        protected final @NotNull BasicRule backer;
+        protected final int index;
+
+        public ProtectedRuleAccess(@NotNull BasicRule backer, int index) {
+            this.backer = backer;
+            this.index = index;
+        }
+
+        @Override
+        public @NotNull AxonAddress getAddress() {
+            return backer.getAddress();
+        }
+
+        @Override
+        public void setAddress(@NotNull AxonAddress address) {
+            backer.setAddress(address);
+            toSync.add(buf -> {
+                buf.writeEnum(RuleAction.MODIFY);
+                buf.writeVarInt(index);
+                buf.writeEnum(ModifyType.ADDRESS);
+                address.write(buf);
+            });
+        }
+
+        @Override
+        public boolean isMatchesIncoming() {
+            return backer.isMatchesIncoming();
+        }
+
+        @Override
+        public void setMatchesIncoming(boolean matchesIncoming) {
+            backer.setMatchesIncoming(matchesIncoming);
+            toSync.add(buf -> {
+                buf.writeEnum(RuleAction.MODIFY);
+                buf.writeVarInt(index);
+                buf.writeEnum(ModifyType.INCOMING);
+                buf.writeBoolean(matchesIncoming);
+            });
+        }
+
+        @Override
+        public boolean isMatchesOutgoing() {
+            return backer.isMatchesOutgoing();
+        }
+
+        @Override
+        public void setMatchesOutgoing(boolean matchesOutgoing) {
+            backer.setMatchesOutgoing(matchesOutgoing);
+            toSync.add(buf -> {
+                buf.writeEnum(RuleAction.MODIFY);
+                buf.writeVarInt(index);
+                buf.writeEnum(ModifyType.OUTGOING);
+                buf.writeBoolean(matchesOutgoing);
+            });
+        }
+
+        public enum ModifyType {
+            ADDRESS, INCOMING, OUTGOING
+        }
+    }
+}

--- a/src/main/java/com/m_w_k/synapse/api/block/ruleset/FluidRule.java
+++ b/src/main/java/com/m_w_k/synapse/api/block/ruleset/FluidRule.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 
-public class FluidRule implements FluidRuleAccess {
+public class FluidRule extends BasicRule implements FluidRuleAccess {
 
     public static final Codec<FluidRule> CODEC = RecordCodecBuilder.create(instance ->
             instance.group(
@@ -23,25 +23,19 @@ public class FluidRule implements FluidRuleAccess {
                     Codec.BOOL.fieldOf("matchNBT").forGetter(FluidRule::isMatchNBT)
             ).apply(instance, FluidRule::new));
 
-    @NotNull
-    protected AxonAddress address = new AxonAddress();
-    protected boolean matchesIncoming;
-    protected boolean matchesOutgoing;
-
     public final FluidStack[] matchStacks;
     protected boolean whitelist = true;
     protected boolean matchNBT;
 
     public FluidRule() {
+        super();
         matchStacks = new FluidStack[9];
         Arrays.fill(matchStacks, FluidStack.EMPTY);
     }
 
     public FluidRule(@NotNull AxonAddress address, boolean matchesIncoming, boolean matchesOutgoing,
                      FluidStack[] matchStacks, boolean whitelist, boolean matchNBT) {
-        this.setAddress(address);
-        this.setMatchesIncoming(matchesIncoming);
-        this.setMatchesOutgoing(matchesOutgoing);
+        super(address, matchesIncoming, matchesOutgoing);
         this.matchStacks = matchStacks;
         this.setWhitelist(whitelist);
         this.setMatchNBT(matchNBT);
@@ -54,36 +48,6 @@ public class FluidRule implements FluidRuleAccess {
             return isWhitelist();
         }
         return !isWhitelist();
-    }
-
-    @Override
-    public @NotNull AxonAddress getAddress() {
-        return address;
-    }
-
-    @Override
-    public void setAddress(@NotNull AxonAddress address) {
-        this.address = address;
-    }
-
-    @Override
-    public boolean isMatchesIncoming() {
-        return matchesIncoming;
-    }
-
-    @Override
-    public void setMatchesIncoming(boolean matchesIncoming) {
-        this.matchesIncoming = matchesIncoming;
-    }
-
-    @Override
-    public boolean isMatchesOutgoing() {
-        return matchesOutgoing;
-    }
-
-    @Override
-    public void setMatchesOutgoing(boolean matchesOutgoing) {
-        this.matchesOutgoing = matchesOutgoing;
     }
 
     @Override

--- a/src/main/java/com/m_w_k/synapse/api/block/ruleset/FluidRuleAccess.java
+++ b/src/main/java/com/m_w_k/synapse/api/block/ruleset/FluidRuleAccess.java
@@ -5,19 +5,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import org.jetbrains.annotations.NotNull;
 
-public interface FluidRuleAccess {
-
-    @NotNull AxonAddress getAddress();
-
-    void setAddress(@NotNull AxonAddress address);
-
-    boolean isMatchesIncoming();
-
-    void setMatchesIncoming(boolean matchesIncoming);
-
-    boolean isMatchesOutgoing();
-
-    void setMatchesOutgoing(boolean matchesOutgoing);
+public interface FluidRuleAccess extends RuleAccess {
 
     FluidStack getMatchStack(int index);
 

--- a/src/main/java/com/m_w_k/synapse/api/block/ruleset/ItemRule.java
+++ b/src/main/java/com/m_w_k/synapse/api/block/ruleset/ItemRule.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 
-public class ItemRule implements ItemRuleAccess {
+public class ItemRule extends BasicRule implements ItemRuleAccess {
 
     public static final Codec<ItemRule> CODEC = RecordCodecBuilder.create(instance ->
             instance.group(
@@ -22,25 +22,19 @@ public class ItemRule implements ItemRuleAccess {
                     Codec.BOOL.fieldOf("matchNBT").forGetter(ItemRule::isMatchNBT)
             ).apply(instance, ItemRule::new));
 
-    @NotNull
-    protected AxonAddress address = new AxonAddress();
-    protected boolean matchesIncoming;
-    protected boolean matchesOutgoing;
-
     public final ItemStack[] matchStacks;
     protected boolean whitelist = true;
     protected boolean matchNBT;
 
     public ItemRule() {
+        super();
         matchStacks = new ItemStack[9];
         Arrays.fill(matchStacks, ItemStack.EMPTY);
     }
 
     public ItemRule(@NotNull AxonAddress address, boolean matchesIncoming, boolean matchesOutgoing,
                     ItemStack[] matchStacks, boolean whitelist, boolean matchNBT) {
-        this.setAddress(address);
-        this.setMatchesIncoming(matchesIncoming);
-        this.setMatchesOutgoing(matchesOutgoing);
+        super(address, matchesIncoming, matchesOutgoing);
         this.matchStacks = matchStacks;
         this.setWhitelist(whitelist);
         this.setMatchNBT(matchNBT);
@@ -53,36 +47,6 @@ public class ItemRule implements ItemRuleAccess {
             return isWhitelist();
         }
         return !isWhitelist();
-    }
-
-    @Override
-    public @NotNull AxonAddress getAddress() {
-        return address;
-    }
-
-    @Override
-    public void setAddress(@NotNull AxonAddress address) {
-        this.address = address;
-    }
-
-    @Override
-    public boolean isMatchesIncoming() {
-        return matchesIncoming;
-    }
-
-    @Override
-    public void setMatchesIncoming(boolean matchesIncoming) {
-        this.matchesIncoming = matchesIncoming;
-    }
-
-    @Override
-    public boolean isMatchesOutgoing() {
-        return matchesOutgoing;
-    }
-
-    @Override
-    public void setMatchesOutgoing(boolean matchesOutgoing) {
-        this.matchesOutgoing = matchesOutgoing;
     }
 
     @Override

--- a/src/main/java/com/m_w_k/synapse/api/block/ruleset/ItemRuleAccess.java
+++ b/src/main/java/com/m_w_k/synapse/api/block/ruleset/ItemRuleAccess.java
@@ -4,19 +4,7 @@ import com.m_w_k.synapse.api.connect.AxonAddress;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-public interface ItemRuleAccess {
-
-    @NotNull AxonAddress getAddress();
-
-    void setAddress(@NotNull AxonAddress address);
-
-    boolean isMatchesIncoming();
-
-    void setMatchesIncoming(boolean matchesIncoming);
-
-    boolean isMatchesOutgoing();
-
-    void setMatchesOutgoing(boolean matchesOutgoing);
+public interface ItemRuleAccess extends RuleAccess {
 
     ItemStack getMatchStack(int index);
 

--- a/src/main/java/com/m_w_k/synapse/api/block/ruleset/RuleAccess.java
+++ b/src/main/java/com/m_w_k/synapse/api/block/ruleset/RuleAccess.java
@@ -1,0 +1,19 @@
+package com.m_w_k.synapse.api.block.ruleset;
+
+import com.m_w_k.synapse.api.connect.AxonAddress;
+import org.jetbrains.annotations.NotNull;
+
+public interface RuleAccess {
+
+    @NotNull AxonAddress getAddress();
+
+    void setAddress(@NotNull AxonAddress address);
+
+    boolean isMatchesIncoming();
+
+    void setMatchesIncoming(boolean matchesIncoming);
+
+    boolean isMatchesOutgoing();
+
+    void setMatchesOutgoing(boolean matchesOutgoing);
+}

--- a/src/main/java/com/m_w_k/synapse/api/connect/AxonAddress.java
+++ b/src/main/java/com/m_w_k/synapse/api/connect/AxonAddress.java
@@ -52,7 +52,7 @@ public final class AxonAddress extends Object2ShortRBTreeMap<ConnectorLevel> {
     }
 
     /**
-     * Creates a wildcard address for matching with other addresses.
+     * Creates a wildcard address for matching with other addresses. Not compatible with serialization.
      * @param universal whether the wildcard should match empty address sections as well.
      * @return an address that by default matches with any other address, and can have specificity added.
      */

--- a/src/main/java/com/m_w_k/synapse/client/gui/RelayScreen.java
+++ b/src/main/java/com/m_w_k/synapse/client/gui/RelayScreen.java
@@ -1,0 +1,17 @@
+package com.m_w_k.synapse.client.gui;
+
+import com.m_w_k.synapse.common.menu.RelayMenu;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+
+public class RelayScreen extends AbstractConnectorScreen<RelayMenu> {
+    public RelayScreen(RelayMenu menu, Inventory playerInventory, Component p_97743_) {
+        super(menu, playerInventory, p_97743_);
+    }
+
+    @Override
+    protected void updateSelectedDeviceScreen() {
+        super.updateSelectedDeviceScreen();
+        addressConfig.setVisible(false);
+    }
+}

--- a/src/main/java/com/m_w_k/synapse/client/gui/ruleset/EnergyRulesetWidget.java
+++ b/src/main/java/com/m_w_k/synapse/client/gui/ruleset/EnergyRulesetWidget.java
@@ -1,0 +1,165 @@
+package com.m_w_k.synapse.client.gui.ruleset;
+
+import com.google.common.collect.ImmutableList;
+import com.m_w_k.synapse.SynapseMod;
+import com.m_w_k.synapse.api.block.ruleset.*;
+import com.m_w_k.synapse.api.connect.AxonAddress;
+import com.m_w_k.synapse.client.gui.AbstractConnectorScreen;
+import com.m_w_k.synapse.client.gui.ActionButton;
+import com.m_w_k.synapse.client.gui.TexDefinition;
+import com.m_w_k.synapse.client.gui.TexLocation;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.components.events.AbstractContainerEventHandler;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class EnergyRulesetWidget extends AbstractContainerEventHandler implements RulesetWidget {
+    static final TexLocation TEX_LOCATION = new TexLocation(SynapseMod.resLoc("textures/gui/container/ruleset.png"), 128, 128);
+
+    protected final EnergyTransferRuleset parent;
+    protected final AbstractConnectorScreen<?> screen;
+    private final int x;
+    private final int y;
+
+    protected int currentRule = 0;
+    protected final ActionButton left;
+    protected final ActionButton right;
+    protected final ActionButton swapLeft;
+    protected final ActionButton swapRight;
+    protected final ActionButton delete;
+    protected final ActionButton add;
+
+    protected @NotNull String lastAddress = "";
+    protected final EditBox addressBox;
+
+    protected final ActionButton filterIncoming;
+    protected final ActionButton filterOutgoing;
+
+    protected final List<AbstractWidget> children;
+
+    public EnergyRulesetWidget(EnergyTransferRuleset parent, AbstractConnectorScreen<?> screen, int x, int y) {
+        this.parent = parent;
+        this.screen = screen;
+        this.x = x;
+        this.y = y;
+
+        ImmutableList.Builder<AbstractWidget> builder = new ImmutableList.Builder<>();
+        ActionButton.ButtonFactory factory = new ActionButton.ButtonFactory(TEX_LOCATION);
+        builder.add(left = factory.button(x, y, 11, Component.translatable("synapse.menu.button.ruleset.left"),
+                () -> currentRule > 0, () -> {
+            currentRule = Math.max(0, currentRule - 1);
+            onRuleChanged();
+        },
+                TexDefinition.noHoverInactive(11, 44, 0, 44, 22, 44),
+                TexDefinition.simple(0, 55)));
+        builder.add(right = factory.button(x + 15, y, 11, Component.translatable("synapse.menu.button.ruleset.right"),
+                () -> currentRule < parent.ruleCount() - 1, () -> {
+            currentRule = Math.min(parent.ruleCount() - 1, currentRule + 1);
+            onRuleChanged();
+        },
+                TexDefinition.noHoverInactive(11, 44, 0, 44, 22, 44),
+                TexDefinition.simple(11, 55)));
+        builder.add(swapLeft = factory.button(x + 65 + 1, y, 11, Component.translatable("synapse.menu.button.ruleset.swap_left"),
+                () -> currentRule > 0, () -> {
+            if (currentRule == 0) return;
+            parent.applyAction(currentRule, RuleAction.SHIFT_LEFT);
+            currentRule--;
+            onRuleChanged();
+        },
+                TexDefinition.noHoverInactive(11, 44, 0, 44, 22, 44),
+                TexDefinition.simple(0, 66)));
+        builder.add(swapRight = factory.button(x + 80 + 1, y, 11, Component.translatable("synapse.menu.button.ruleset.swap_right"),
+                () -> currentRule < parent.ruleCount() - 1, () -> {
+            if (currentRule >= parent.ruleCount() - 1) return;
+            parent.applyAction(currentRule, RuleAction.SHIFT_RIGHT);
+            currentRule++;
+            onRuleChanged();
+        },
+                TexDefinition.noHoverInactive(11, 44, 0, 44, 22, 44),
+                TexDefinition.simple(11, 66)));
+        builder.add(delete = factory.button(x + 95 + 1, y, 11, Component.translatable("synapse.menu.button.ruleset.delete"),
+                () -> true /* replace with check to see if the rule is not the default rule */, () -> {
+            parent.applyAction(currentRule, RuleAction.DELETE);
+            if (currentRule == parent.ruleCount()) currentRule--;
+            onRuleChanged();
+        },
+                TexDefinition.noHoverInactive(11, 44, 0, 44, 22, 44),
+                TexDefinition.simple(0, 77)));
+        builder.add(add = factory.button(x + 110 + 1, y, 11, Component.translatable("synapse.menu.button.ruleset.add"),
+                () -> parent.ruleCount() < 50, () -> {
+            if (parent.ruleCount() >= 50) return;
+            currentRule += 1;
+            parent.applyAction(currentRule, RuleAction.ADD);
+            onRuleChanged();
+        },
+                TexDefinition.noHoverInactive(11, 44, 0, 44, 22, 44),
+                TexDefinition.simple(11, 77)));
+
+        builder.add(addressBox = new EditBox(screen.getFontRenderer(), x, y + 15, 120, 14, Component.translatable("synapse.menu.ruleset.address_config")));
+
+        builder.add(filterIncoming = factory.button(x, y + 35, 22, Component.translatable("synapse.menu.button.ruleset.incoming"),
+                () -> currentRule().isMatchesIncoming(), () -> currentRule().setMatchesIncoming(!currentRule().isMatchesIncoming()),
+                new TexDefinition(0, 0, 22, 0, 0, 22, 22, 22),
+                TexDefinition.active(44, 44, 66, 44)));
+        builder.add(filterOutgoing = factory.button(x + 25, y + 35, 22, Component.translatable("synapse.menu.button.ruleset.outgoing"),
+                () -> currentRule().isMatchesOutgoing(), () -> currentRule().setMatchesOutgoing(!currentRule().isMatchesOutgoing()),
+                new TexDefinition(0, 0, 22, 0, 0, 22, 22, 22),
+                TexDefinition.active(44, 66, 66, 66)));
+        children = builder.build();
+
+        addressBox.setMaxLength(50);
+    }
+
+    protected RuleAccess currentRule() {
+        return parent.ruleAt(currentRule);
+    }
+
+    @Override
+    public void updateSelectedDevice() {
+        onRuleChanged();
+    }
+
+    protected void onRuleChanged() {
+        addressBox.setValue(currentRule().getAddress().toString());
+    }
+
+    @Override
+    public void containerTick() {
+        addressBox.tick();
+        if (!lastAddress.equals(addressBox.getValue())) {
+            lastAddress = addressBox.getValue();
+            AxonAddress.parse(lastAddress).ifLeft(a -> currentRule().setAddress(a));
+        }
+    }
+
+    @Override
+    public @NotNull List<? extends GuiEventListener> children() {
+        return children;
+    }
+
+    @Override
+    public void render(@NotNull GuiGraphics graphics, int mouseX, int mouseY, float partial) {
+        for (var child : children) {
+            child.render(graphics, mouseX, mouseY, partial);
+            String s = String.valueOf(currentRule + 1);
+            graphics.drawString(screen.getFontRenderer(), s + " / " + parent.ruleCount(), x + 39 - screen.getFontRenderer().width(s), y + 2, 0xFFFFFF, false);
+        }
+    }
+
+    public @NotNull NarrationPriority narrationPriority() {
+        if (this.isFocused()) {
+            return NarrationPriority.FOCUSED;
+        } else {
+            return NarrationPriority.NONE;
+        }
+    }
+
+    public final void updateNarration(@NotNull NarrationElementOutput p_259921_) {}
+
+}

--- a/src/main/java/com/m_w_k/synapse/common/block/RelayBlock.java
+++ b/src/main/java/com/m_w_k/synapse/common/block/RelayBlock.java
@@ -5,9 +5,14 @@ import com.m_w_k.synapse.api.block.IAxonBlockEntity;
 import com.m_w_k.synapse.common.block.entity.AxonBlockEntity;
 import com.m_w_k.synapse.common.block.entity.RelayBlockEntity;
 import com.m_w_k.synapse.common.item.AxonItem;
+import com.m_w_k.synapse.common.menu.BasicConnectorMenu;
+import com.m_w_k.synapse.common.menu.RelayMenu;
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.MenuProvider;
+import net.minecraft.world.SimpleMenuProvider;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
@@ -24,6 +29,7 @@ import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraftforge.network.NetworkHooks;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -40,8 +46,11 @@ public class RelayBlock extends AxonBlock implements SimpleWaterloggedBlock {
     }
 
     @Override
-    protected boolean hasInteractMenu() {
-        return false;
+    protected void openInteractMenu(@NotNull ServerPlayer player, @NotNull Level level, @NotNull BlockState state, @NotNull BlockPos pos, @NotNull IAxonBlockEntity be) {
+        MenuProvider prov = new SimpleMenuProvider(
+                (containerId, playerInventory, p) -> RelayMenu.of(containerId, playerInventory, be),
+                Component.translatable("synapse.menu.title.relay"));
+        NetworkHooks.openScreen(player, prov, RelayMenu.writer(be));
     }
 
     @Override

--- a/src/main/java/com/m_w_k/synapse/common/block/entity/RelayBlockEntity.java
+++ b/src/main/java/com/m_w_k/synapse/common/block/entity/RelayBlockEntity.java
@@ -62,7 +62,8 @@ public class RelayBlockEntity extends AxonBlockEntity {
 
     @Override
     public @NotNull String getNameBySlot(int slot) {
-        return Integer.toString(slot);
+        var pair = AxonDeviceDefinitions.RELAYS_INV.get(slot);
+        return pair.value().name() + "_" + pair.keyInt();
     }
 
     @Override

--- a/src/main/java/com/m_w_k/synapse/common/connect/EnergyExposer.java
+++ b/src/main/java/com/m_w_k/synapse/common/connect/EnergyExposer.java
@@ -1,19 +1,26 @@
 package com.m_w_k.synapse.common.connect;
 
 import com.m_w_k.synapse.api.block.IFacedAxonBlockEntity;
+import com.m_w_k.synapse.api.block.ruleset.EnergyTransferRuleset;
+import com.m_w_k.synapse.api.block.ruleset.FluidTransferRuleset;
 import com.m_w_k.synapse.api.block.ruleset.TransferRuleset;
 import com.m_w_k.synapse.api.connect.AxonTree;
 import com.m_w_k.synapse.api.connect.AxonType;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.ByteTag;
+import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.energy.IEnergyStorage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
+import java.util.function.UnaryOperator;
 
 public class EnergyExposer extends AbstractExposer<IEnergyStorage, EnergyExposer, Void> implements IEnergyStorage {
+
+    protected EnergyTransferRuleset ruleset = new EnergyTransferRuleset(Dist.DEDICATED_SERVER);
 
     public EnergyExposer(@NotNull IFacedAxonBlockEntity owner) {
         super(owner);
@@ -31,15 +38,22 @@ public class EnergyExposer extends AbstractExposer<IEnergyStorage, EnergyExposer
 
     @Override
     protected @NotNull Tag save() {
-        return ByteTag.valueOf((byte) 0);
+        return EnergyTransferRuleset.CODEC.encodeStart(NbtOps.INSTANCE, this.ruleset).get()
+                .map(UnaryOperator.identity(), e -> ByteTag.valueOf((byte) 0));
     }
 
     @Override
-    protected void load(@NotNull Tag nbt) {}
+    protected void load(@NotNull Tag nbt) {
+        EnergyTransferRuleset.CODEC.parse(NbtOps.INSTANCE, nbt).get()
+                .ifLeft(ruleset -> {
+                    this.ruleset = ruleset;
+                    ruleset.setChangeListener(this::setDirty);
+                });
+    }
 
     @Override
     public TransferRuleset.@Nullable QueryableRuleset<Void> getRuleset() {
-        return null;
+        return ruleset;
     }
 
     @Override

--- a/src/main/java/com/m_w_k/synapse/common/menu/RelayMenu.java
+++ b/src/main/java/com/m_w_k/synapse/common/menu/RelayMenu.java
@@ -1,0 +1,49 @@
+package com.m_w_k.synapse.common.menu;
+
+import com.m_w_k.synapse.api.block.IAxonBlockEntity;
+import com.m_w_k.synapse.api.block.ruleset.TransferRuleset;
+import com.m_w_k.synapse.api.connect.IDSetResult;
+import com.m_w_k.synapse.common.block.entity.EndpointBlockEntity;
+import com.m_w_k.synapse.network.EndpointRulesetSyncPacket;
+import com.m_w_k.synapse.network.SynapsePacketHandler;
+import com.m_w_k.synapse.registry.SynapseMenuRegistry;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.ContainerLevelAccess;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.network.PacketDistributor;
+
+import java.nio.charset.Charset;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+
+public class RelayMenu extends BasicConnectorMenu {
+
+    public RelayMenu(int containerID, Inventory playerInv, ContainerLevelAccess access, IntFunction<String> deviceNames, int deviceCount) {
+        super(SynapseMenuRegistry.RELAY.get(), containerID, playerInv, access, deviceNames, deviceCount);
+    }
+
+    public static RelayMenu of(int containerID, Inventory playerInv, IAxonBlockEntity be) {
+        RelayMenu menu = new RelayMenu(containerID, playerInv, ContainerLevelAccess.create(be.getLevel(), be.getBlockPos()), be::getNameBySlot, be.getSlots());
+        menu.be = be;
+        return menu;
+    }
+
+    public static RelayMenu read(int containerID, Inventory playerInv, FriendlyByteBuf buf) {
+        int slots = buf.readVarInt();
+        String[] names = new String[slots];
+        for (int i = 0; i < slots; i++) {
+            int length = buf.readVarInt();
+            names[i] = buf.readCharSequence(length, Charset.defaultCharset()).toString();
+        }
+        RelayMenu ret = new RelayMenu(containerID, playerInv, ContainerLevelAccess.NULL, i -> names[i], slots);
+        ret.setActiveDevices(buf.readBitSet());
+        return ret;
+    }
+
+    public static Consumer<FriendlyByteBuf> writer(IAxonBlockEntity be) {
+        return BasicConnectorMenu.writer(be);
+    }
+}

--- a/src/main/java/com/m_w_k/synapse/registry/SynapseMenuRegistry.java
+++ b/src/main/java/com/m_w_k/synapse/registry/SynapseMenuRegistry.java
@@ -3,6 +3,7 @@ package com.m_w_k.synapse.registry;
 import com.m_w_k.synapse.SynapseMod;
 import com.m_w_k.synapse.common.menu.BasicConnectorMenu;
 import com.m_w_k.synapse.common.menu.EndpointMenu;
+import com.m_w_k.synapse.common.menu.RelayMenu;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraftforge.common.extensions.IForgeMenuType;
@@ -16,6 +17,7 @@ public final class SynapseMenuRegistry {
 
     public static final RegistryObject<MenuType<BasicConnectorMenu>> BASIC_CONNECTOR = MENUS.register("basic_connector", () -> IForgeMenuType.create(BasicConnectorMenu::read));
     public static final RegistryObject<MenuType<EndpointMenu>> ENDPOINT = MENUS.register("endpoint", () -> IForgeMenuType.create(EndpointMenu::read));
+    public static final RegistryObject<MenuType<RelayMenu>> RELAY = MENUS.register("relay", () -> IForgeMenuType.create(RelayMenu::read));
 
     public static void init(IEventBus bus) {
         MENUS.register(bus);

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,2 +1,1 @@
-public com.mojang.blaze3d.vertex.BufferBuilder f_85648_ # buffer
 public net.minecraftforge.common.util.LazyOptional resolved

--- a/src/main/resources/assets/synapse/lang/en_us.json
+++ b/src/main/resources/assets/synapse/lang/en_us.json
@@ -2,6 +2,7 @@
   "itemGroup.synapse": "Synapse",
 
   "synapse.menu.title.basic_connector": "Connector",
+  "synapse.menu.title.relay": "Relay",
   "synapse.menu.title.endpoint": "Endpoint",
   "synapse.menu.search": "Search",
   "synapse.menu.address_config": "Device ID",


### PR DESCRIPTION
Adds an energy ruleset for destination configuration, and a relay menu so that the upstream connection can be removed without removing the relay.